### PR TITLE
Fix page not loaded during ToDorfCommand

### DIFF
--- a/MainCore/Services/ChromeBrowser.cs
+++ b/MainCore/Services/ChromeBrowser.cs
@@ -240,7 +240,7 @@ namespace MainCore.Services
                 }
                 catch (WebDriverTimeoutException)
                 {
-                    return Result.Fail(new Stop("Page not loaded in 3 mins"));
+                    return new Retry("Page not loaded in 3 mins");
                 }
                 if (cancellationToken.IsCancellationRequested) return Result.Fail(new Cancel());
                 return Result.Ok();


### PR DESCRIPTION
Sometimes bot is stuck when switching to dorf*. Replacing `Error `with `Retry `inside ChromeBrowser's `Wait` method seems to fix the issue. I've been running it for a few days now without encountering any errors. The underlying task will be retried according to the retry policy set inside TimerManager."

![image](https://github.com/vinaghost/TravianBotSharp/assets/1367334/e529ee15-5197-427f-aee5-185a4dba5b3b)
