### PR TITLE
Fixed 'Cannot new add account'

### DIFF
--- a/MainCore/UI/ViewModels/Tabs/AddAccountViewModel.cs
+++ b/MainCore/UI/ViewModels/Tabs/AddAccountViewModel.cs
@@ -54,6 +54,11 @@ namespace MainCore.UI.ViewModels.Tabs
                 return;
             }
 
+            if (string.IsNullOrEmpty(AccountInput.Username))
+            {
+                AccountInput.Username = AccessInput.Username;
+            }
+
             AccountInput.Accesses.Add(AccessInput.Clone());
         }
 


### PR DESCRIPTION
Added string empty or null check on account username