### PR TITLE
FIx cannot read plus account status

### DIFF
--- a/MainCore/Parsers/InfoParser.cs
+++ b/MainCore/Parsers/InfoParser.cs
@@ -18,11 +18,13 @@
 
         public static bool HasPlusAccount(HtmlDocument doc)
         {
-            var market = doc.DocumentNode.Descendants("a").FirstOrDefault(x => x.HasClass("market") && x.HasClass("round"));
-            if (market is null) return false;
+            var boxLink = doc.GetElementbyId("sidebarBoxLinklist");
+            if (boxLink is null) return false;
+            var editButton = boxLink.Descendants("a").FirstOrDefault(x => x.HasClass("edit") && x.HasClass("round"));
+            if (editButton is null) return false;
 
-            if (market.HasClass("green")) return true;
-            if (market.HasClass("gold")) return false;
+            if (editButton.HasClass("green")) return true;
+            if (editButton.HasClass("gold")) return false;
             return false;
         }
     }


### PR DESCRIPTION
The HasPlusAccount method in InfoParser.cs has been updated to change the way it determines if a user has a Plus account. Previously, it checked for an element with classes "market" and "round" and then checked its color (green or gold). The new implementation now looks for an element with the ID "sidebarBoxLinklist" and checks for a descendant element with classes "edit" and "round". The color check is now performed on this "edit" element.


Yes, I use AI to generate this message 