### PR TITLE
Train troop task go wrong building

### DIFF
--- a/MainCore/Commands/Features/NpcResource/ToNpcResourcePageCommand.cs
+++ b/MainCore/Commands/Features/NpcResource/ToNpcResourcePageCommand.cs
@@ -21,7 +21,7 @@
             result = await updateBuildingCommand.HandleAsync(new(villageId), cancellationToken);
             if (result.IsFailed) return result;
 
-            result = await toBuildingCommand.HandleAsync(new(BuildingEnums.Marketplace), cancellationToken);
+            result = await toBuildingCommand.HandleAsync(new(villageId, BuildingEnums.Marketplace), cancellationToken);
             if (result.IsFailed) return result;
 
             result = await switchTabCommand.HandleAsync(new(0), cancellationToken);

--- a/MainCore/Commands/Features/TrainTroop/ToTrainTroopPageCommand.cs
+++ b/MainCore/Commands/Features/TrainTroop/ToTrainTroopPageCommand.cs
@@ -20,7 +20,7 @@
             var (_, isFailed, errors) = await updateBuildingCommand.HandleAsync(new(villageId), cancellationToken);
             if (isFailed) return Result.Fail(errors);
 
-            result = await toBuildingCommand.HandleAsync(new(building), cancellationToken);
+            result = await toBuildingCommand.HandleAsync(new(villageId, building), cancellationToken);
             if (result.IsFailed) return result;
 
             return Result.Ok();

--- a/MainCore/Commands/Navigate/ToBuildingByTypeCommand.cs
+++ b/MainCore/Commands/Navigate/ToBuildingByTypeCommand.cs
@@ -3,7 +3,7 @@
     [Handler]
     public static partial class ToBuildingByTypeCommand
     {
-        public sealed record Command(BuildingEnums Type) : ICommand;
+        public sealed record Command(VillageId VillageId, BuildingEnums Type) : ICommand;
 
         private static async ValueTask<Result> HandleAsync(
            Command command,
@@ -13,9 +13,10 @@
            )
         {
             var marketLocation = context.Buildings
-               .Where(x => x.Type == command.Type)
-               .Select(x => x.Location)
-               .FirstOrDefault();
+                .Where(x => x.VillageId == command.VillageId.Value)
+                .Where(x => x.Type == command.Type)
+                .Select(x => x.Location)
+                .FirstOrDefault();
 
             if (marketLocation == default)
             {


### PR DESCRIPTION
Updated `ToNpcResourcePageCommand` and `ToTrainTroopPageCommand` to include `villageId` in `toBuildingCommand.HandleAsync` calls for better context handling.

Modified `ToBuildingByTypeCommand` to include `VillageId` in the command record and adjusted the market location query to filter by both `VillageId` and `Type`.