### PR TITLE
Fix humanize exception TimeSpanHumanizeMultipleSeconds was not found 

### DIFF
--- a/MainCore/Services/TimerManager.cs
+++ b/MainCore/Services/TimerManager.cs
@@ -48,7 +48,7 @@ namespace MainCore.Services
                     }
                 }
 
-                browser.Logger.Warning("{TaskName} will retry after {RetryDelay} (#{AttemptNumber} times)", taskName, args.RetryDelay.Humanize(3, minUnit: Humanizer.Localisation.TimeUnit.Second), args.AttemptNumber + 1);
+                browser.Logger.Warning("{TaskName} will retry after {RetryDelay} (#{AttemptNumber} times)", taskName, args.RetryDelay.Humanize(3), args.AttemptNumber + 1);
             };
 
             var retryOptions = new RetryStrategyOptions<Result>()

--- a/MainCore/Services/TimerManager.cs
+++ b/MainCore/Services/TimerManager.cs
@@ -1,5 +1,4 @@
-﻿using Humanizer;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Polly;
 using Polly.Retry;
 using Timer = System.Timers.Timer;
@@ -48,7 +47,7 @@ namespace MainCore.Services
                     }
                 }
 
-                browser.Logger.Warning("{TaskName} will retry after {RetryDelay} (#{AttemptNumber} times)", taskName, args.RetryDelay.Humanize(3), args.AttemptNumber + 1);
+                browser.Logger.Warning("{TaskName} will retry after {RetryDelay} (#{AttemptNumber} times)", taskName, args.RetryDelay, args.AttemptNumber + 1);
             };
 
             var retryOptions = new RetryStrategyOptions<Result>()


### PR DESCRIPTION
Removed the `minUnit` parameter from the `Humanize` method call for `args.RetryDelay`. This change relies on the default behavior of the `Humanize` method and simplifies the code by only specifying the precision argument (`3`).