### PR TITLE
Fix cannot use resource from hero inventory part 2 

### DIFF
--- a/MainCore/Parsers/InventoryParser.cs
+++ b/MainCore/Parsers/InventoryParser.cs
@@ -7,7 +7,7 @@
             var heroDiv = doc.GetElementbyId("heroV2");
             if (heroDiv is null) return false;
             var aNode = heroDiv.Descendants("a")
-                .FirstOrDefault(x => x.GetAttributeValue("data-tab", 0) == 1);
+                .FirstOrDefault(x => x.HasClass("tabItem"));
             if (aNode is null) return false;
             return aNode.HasClass("active");
         }


### PR DESCRIPTION
Refactor the `IsInventoryPage` method in `InventoryParser.cs` to change the logic for selecting `<a>` nodes within the `heroDiv` element. Replaced the `GetAttributeValue` check for `data-tab` with a `HasClass` check for the `tabItem` class. This improves the clarity and maintainability of the node selection logic.