### PR TITLE
account not initialize when using add accounts feature

### DIFF
--- a/MainCore/Commands/UI/AddAccountsViewModel/AddAccountsCommand.cs
+++ b/MainCore/Commands/UI/AddAccountsViewModel/AddAccountsCommand.cs
@@ -46,9 +46,9 @@
                         Value = value,
                     });
                 }
+                context.Add(account);
             }
 
-            context.AddRange(accounts);
             context.SaveChanges();
 
             rxQueue.Enqueue(new AccountsModified());


### PR DESCRIPTION
Replaced context.AddRange(accounts) with context.Add(account) in a loop to add each account individually before saving changes. This may improve control over entity tracking or validation. Other logic remains unchanged.