### PR TITLE
fix: set default dorf to 2 when currentDorf is 0

### DIFF
--- a/MainCore/Commands/Navigate/ToDorfCommand.cs
+++ b/MainCore/Commands/Navigate/ToDorfCommand.cs
@@ -17,7 +17,7 @@
             var currentDorf = GetCurrentDorf(currentUrl);
             if (dorf == 0)
             {
-                if (currentDorf == 0) dorf = 1;
+                if (currentDorf == 0) dorf = 2;
                 else dorf = currentDorf;
             }
 


### PR DESCRIPTION
Changed logic to assign dorf as 2 instead of 1 when both dorf and currentDorf are 0, ensuring correct default behavior.

fix #164 