### PR TITLE
Fix: bot gets stuck in Paused state after retry exhaustion (add auto-restart option)

### DIFF
--- a/MainCore/Enums/AccountSettingEnums.cs
+++ b/MainCore/Enums/AccountSettingEnums.cs
@@ -1,4 +1,4 @@
-﻿namespace MainCore.Enums
+namespace MainCore.Enums
 {
     public enum AccountSettingEnums
     {
@@ -17,5 +17,6 @@
         SleepTimeMax,
         HeadlessChrome,
         EnableAutoStartAdventure,
+        EnableAutoRestartOnFailure,
     }
 }

--- a/MainCore/Infrasturecture/Persistence/AppDbContext.cs
+++ b/MainCore/Infrasturecture/Persistence/AppDbContext.cs
@@ -1,4 +1,4 @@
-﻿using StronglyTypedIds;
+using StronglyTypedIds;
 using System.Collections.Immutable;
 
 [assembly: StronglyTypedIdDefaults(backingType: StronglyTypedIdBackingType.Int, converters: StronglyTypedIdConverter.None)]
@@ -47,6 +47,7 @@ namespace MainCore.Infrasturecture.Persistence
             {AccountSettingEnums.WorkTimeMax, 720 },
             {AccountSettingEnums.HeadlessChrome, 0 },
             {AccountSettingEnums.EnableAutoStartAdventure, 0 },
+            {AccountSettingEnums.EnableAutoRestartOnFailure, 0 },
         }.ToImmutableDictionary();
 
         private List<AccountSettingEnums> GetMissingAccountSettings()

--- a/MainCore/Services/TimerManager.cs
+++ b/MainCore/Services/TimerManager.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Polly;
 using Polly.Retry;
 using Timer = System.Timers.Timer;
@@ -152,7 +152,29 @@ namespace MainCore.Services
                     {
                         var filename = await browser.Screenshot();
                         logger.Information(messageTemplate: "Screenshot saved as {FileName}", filename);
-                        _taskManager.SetStatus(accountId, StatusEnums.Paused);
+
+                        if (result.HasError<Retry>() && !result.HasError<Stop>())
+                        {
+                            var settingService = scope.ServiceProvider.GetRequiredService<ISettingService>();
+                            var autoRestart = settingService.BooleanByName(accountId, AccountSettingEnums.EnableAutoRestartOnFailure);
+                            if (autoRestart)
+                            {
+                                logger.Information("Auto restart is enabled. Restarting bot");
+                                _taskManager.SetStatus(accountId, StatusEnums.Starting);
+                                await Task.Delay(300);
+                                _taskManager.Clear(accountId);
+                                _rxQueue.Enqueue(new AccountInit(accountId));
+                                _taskManager.SetStatus(accountId, StatusEnums.Online);
+                            }
+                            else
+                            {
+                                _taskManager.SetStatus(accountId, StatusEnums.Paused);
+                            }
+                        }
+                        else
+                        {
+                            _taskManager.SetStatus(accountId, StatusEnums.Paused);
+                        }
                     }
                     else if (result.HasError<Skip>())
                     {

--- a/MainCore/UI/Models/Input/AccountSettingInput.cs
+++ b/MainCore/UI/Models/Input/AccountSettingInput.cs
@@ -1,4 +1,4 @@
-﻿using MainCore.UI.ViewModels.Abstract;
+using MainCore.UI.ViewModels.Abstract;
 using MainCore.UI.ViewModels.UserControls;
 
 namespace MainCore.UI.Models.Input
@@ -17,6 +17,7 @@ namespace MainCore.UI.Models.Input
             EnableAutoStartAdventure = settings.GetValueOrDefault(AccountSettingEnums.EnableAutoStartAdventure) == 1;
             FarmInterval.Set(settings.GetValueOrDefault(AccountSettingEnums.FarmIntervalMin), settings.GetValueOrDefault(AccountSettingEnums.FarmIntervalMax));
             UseStartAllButton = settings.GetValueOrDefault(AccountSettingEnums.UseStartAllButton) == 1;
+            EnableAutoRestartOnFailure = settings.GetValueOrDefault(AccountSettingEnums.EnableAutoRestartOnFailure) == 1;
         }
 
         public Dictionary<AccountSettingEnums, int> Get()
@@ -32,6 +33,7 @@ namespace MainCore.UI.Models.Input
 
             var (farmIntervalMin, farmIntervalMax) = FarmInterval.Get();
             var useStartAllButton = UseStartAllButton ? 1 : 0;
+            var autoRestartOnFailure = EnableAutoRestartOnFailure ? 1 : 0;
 
             var settings = new Dictionary<AccountSettingEnums, int>()
             {
@@ -53,6 +55,7 @@ namespace MainCore.UI.Models.Input
 
                 { AccountSettingEnums.HeadlessChrome, headlessChrome },
                 { AccountSettingEnums.EnableAutoStartAdventure, autoStartAdventure },
+                { AccountSettingEnums.EnableAutoRestartOnFailure, autoRestartOnFailure },
             };
             return settings;
         }
@@ -76,5 +79,8 @@ namespace MainCore.UI.Models.Input
 
         [Reactive]
         private bool _useStartAllButton;
+
+        [Reactive]
+        private bool _enableAutoRestartOnFailure;
     }
 }

--- a/WPFUI/Views/Tabs/AccountSettingTab.xaml
+++ b/WPFUI/Views/Tabs/AccountSettingTab.xaml
@@ -1,4 +1,4 @@
-﻿<v:AccountSettingTabBase
+<v:AccountSettingTabBase
     x:Class="WPFUI.Views.Tabs.AccountSettingTab"
     xmlns:v="clr-namespace:WPFUI.Views.Tabs"
     xmlns:uc="clr-namespace:WPFUI.Views.UserControls"
@@ -57,6 +57,7 @@
                         <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="Feature settings" VerticalAlignment="Center" FontWeight="Bold" />
                         <CheckBox x:Name="EnableAutoLoadVillage" Content="Enable auto load village's building" />
                         <CheckBox x:Name="EnableAutoStartAdventure" Content="Enable auto start adventure" />
+                        <CheckBox x:Name="EnableAutoRestartOnFailure" Content="Enable auto restart on failure" />
                     </StackPanel>
                 </Border>
                 <Border Style="{DynamicResource Box}">

--- a/WPFUI/Views/Tabs/AccountSettingTab.xaml.cs
+++ b/WPFUI/Views/Tabs/AccountSettingTab.xaml.cs
@@ -1,4 +1,4 @@
-﻿using MainCore.UI.ViewModels.Tabs;
+using MainCore.UI.ViewModels.Tabs;
 using ReactiveUI;
 using System.Reactive.Disposables.Fluent;
 
@@ -30,6 +30,7 @@ namespace WPFUI.Views.Tabs
                 this.Bind(ViewModel, vm => vm.AccountSettingInput.Tribe, v => v.Tribes.ViewModel).DisposeWith(d);
                 this.Bind(ViewModel, vm => vm.AccountSettingInput.HeadlessChrome, v => v.HeadlessChrome.IsChecked).DisposeWith(d);
                 this.Bind(ViewModel, vm => vm.AccountSettingInput.EnableAutoStartAdventure, v => v.EnableAutoStartAdventure.IsChecked).DisposeWith(d);
+                this.Bind(ViewModel, vm => vm.AccountSettingInput.EnableAutoRestartOnFailure, v => v.EnableAutoRestartOnFailure.IsChecked).DisposeWith(d);
             });
         }
     }


### PR DESCRIPTION
# Changelog

## [Unreleased] — Auto-restart on failure

### Problem

After exhausting all retry attempts (e.g., a timeout while working with the hero inventory), the bot sets its status to `Paused` and completely stops. Recovery requires manually clicking Resume/Restart in the UI.

**Root cause:** In the code (`TimerManager.cs`), after all retry attempts are exhausted, the bot always transitions to the `Paused` state, and the timer (`Execute()`) checks `if (status != StatusEnums.Online) return;` — so no further tasks are executed. There was no auto-restart logic.

**Specific scenario from logs:**
1. The bot is building Warehouse lvl 20 but lacks resources (Wood: 103/6750, Clay: 113/8310, Iron: 128/4675)
2. `UseHeroResourceForBuilding` is enabled → the bot switches to the hero inventory
3. `ValidateEnoughResourceCommand` checks the **database** (`context.HeroItems`) — the database says "resources are available"
4. `UseHeroItemCommand` attempts to click the item on the page (`InventoryParser.GetItemSlot`)
5. The item is **actually missing** on the page (stale DB data or the page failed to load)
6. `GetItemSlot()` → `null` → Selenium WebDriver waits 180 seconds → `WebDriverTimeoutException` → `Retry` error
7. Polly retry runs 3 times (4 attempts × 180s = ~12 minutes)
8. After retries are exhausted → `_taskManager.SetStatus(accountId, StatusEnums.Paused)` → bot is stopped

### Solution

A new option **"Enable auto restart on failure"** has been added to account settings.

### Modified files

| File | Change |
|------|--------|
| `MainCore/Enums/AccountSettingEnums.cs` | Added `EnableAutoRestartOnFailure` to enum |
| `MainCore/Services/TimerManager.cs` | On `Retry` error, checks setting; if enabled → auto-restart (Starting → Clear → AccountInit → Online) instead of Paused |
| `MainCore/UI/Models/Input/AccountSettingInput.cs` | Added `EnableAutoRestartOnFailure` property with getter/setter |
| `MainCore/Infrasturecture/Persistence/AppDbContext.cs` | Added default value to AccountDefaultSettings (persistence fix) |
| `WPFUI/Views/Tabs/AccountSettingTab.xaml` | Added checkbox "Enable auto restart on failure" in Feature settings section |
| `WPFUI/Views/Tabs/AccountSettingTab.xaml.cs` | Added binding for the checkbox to the ViewModel |

### Behavior

- The option is **disabled by default** (old behavior — the bot pauses)
- When **enabled**:
  - After a `Retry` error, the bot logs `"Auto restart is enabled. Restarting bot"`
  - Clears all tasks, reinitializes the account (AccountInit), and continues working
  - Status: `Starting` → `Online` (account remains green)
- `Stop` errors (critical, e.g., "Driver is not ready") always set `Paused` regardless of the setting